### PR TITLE
Fix vega x-domain bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Tagup Changelog
+
+## 2023-06-22
+- Removed the use of the `expressionInterpreter` when rendering Vega Lite charts. Using this renderer exposes a bug where a specified x-domain results in charts not rendering correctly. See these threads for more details: https://discuss.streamlit.io/t/time-axis-with-custom-scale/33524 https://github.com/vega/vega/issues/3632
+- Pinned `wheel` to 0.40.0 to fix a build error

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit-browser",
-  "version": "1.23.1",
+  "version": "1.23.1.dev1",
   "private": true,
   "homepage": "./",
   "scripts": {

--- a/frontend/src/lib/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
+++ b/frontend/src/lib/components/elements/ArrowVegaLiteChart/ArrowVegaLiteChart.tsx
@@ -18,7 +18,7 @@ import React, { PureComponent } from "react"
 import { withTheme } from "@emotion/react"
 import embed from "vega-embed"
 import * as vega from "vega"
-import { expressionInterpreter } from "vega-interpreter"
+// import { expressionInterpreter } from "vega-interpreter"
 
 import { logMessage } from "src/lib/util/log"
 import withFullScreenWrapper from "src/lib/hocs/withFullScreenWrapper"
@@ -327,8 +327,8 @@ export class ArrowVegaLiteChart extends PureComponent<PropsWithHeight, State> {
     const options = {
       defaultStyle: true,
       // Adds interpreter support for Vega expressions that is compliant with CSP
-      ast: true,
-      expr: expressionInterpreter,
+      // ast: true,
+      // expr: expressionInterpreter,
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)

--- a/frontend/src/lib/components/elements/VegaLiteChart/VegaLiteChart.tsx
+++ b/frontend/src/lib/components/elements/VegaLiteChart/VegaLiteChart.tsx
@@ -29,7 +29,7 @@ import { ensureError } from "src/lib/util/ErrorHandling"
 import { EmotionTheme } from "src/lib/theme"
 import embed from "vega-embed"
 import * as vega from "vega"
-import { expressionInterpreter } from "vega-interpreter"
+// import { expressionInterpreter } from "vega-interpreter"
 import { StyledVegaLiteChartContainer } from "./styled-components"
 
 const MagicFields = {
@@ -286,8 +286,8 @@ export class VegaLiteChart extends PureComponent<PropsWithHeight, State> {
     const spec = this.generateSpec()
     const options = {
       // Adds interpreter support for Vega expressions that is compliant with CSP
-      ast: true,
-      expr: expressionInterpreter,
+      // ast: true,
+      // expr: expressionInterpreter,
     }
 
     const { vgSpec, view, finalize } = await embed(this.element, spec, options)

--- a/lib/dev-requirements.txt
+++ b/lib/dev-requirements.txt
@@ -14,7 +14,7 @@ semver<3
 setuptools>=65.5.1
 testfixtures
 twine
-wheel
+wheel>=0.40.0
 # mypy types
 types-click
 types-protobuf

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.install import install
 
 THIS_DIRECTORY = Path(__file__).parent
 
-VERSION = "1.23.1"  # PEP-440
+VERSION = "1.23.1.dev1"  # PEP-440
 
 NAME = "streamlit"
 


### PR DESCRIPTION
- Removed the use of the `expressionInterpreter` when rendering Vega Lite charts. Using this renderer exposes a bug where a specified x-domain results in charts not rendering correctly. See these threads for more details: https://discuss.streamlit.io/t/time-axis-with-custom-scale/33524 https://github.com/vega/vega/issues/3632
- Pinned `wheel` to 0.40.0 to fix a build error