### PR TITLE
Create OnPurposeRerunException for st.experimental_rerun()

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamlit",
-  "version": "1.25.0",
+  "version": "1.25.0.dev1",
   "private": true,
   "workspaces": ["app", "lib"],
   "scripts": {

--- a/lib/setup.py
+++ b/lib/setup.py
@@ -21,7 +21,7 @@ from setuptools.command.install import install
 
 THIS_DIRECTORY = Path(__file__).parent
 
-VERSION = "1.25.0"  # PEP-440
+VERSION = "1.25.0.dev1"  # PEP-440
 
 NAME = "streamlit"
 
@@ -52,21 +52,12 @@ INSTALL_REQUIRES = [
     # upper bound on it.
     "pyarrow>=6.0",
     "pympler>=0.9, <2",
-<<<<<<< HEAD
-    "python-dateutil>=2, <3",
-    "requests>=2.4, <3",
-    "rich>=10.11.0, <14",
-    "tenacity>=8.0.0, <9",
-    "toml<2",
-    "typing-extensions>=4.0.1, <5",
-=======
     "python-dateutil>=2.7.3, <3",
     "requests>=2.18, <3",
     "rich>=10.14.0, <14",
     "tenacity>=8.1.0, <9",
     "toml>=0.10.1, <2",
     "typing-extensions>=4.1.0, <5",
->>>>>>> release/1.25.0
     "tzlocal>=1.1, <5",
     "validators>=0.2, <1",
     # Don't require watchdog on MacOS, since it'll fail without xcode tools.

--- a/lib/streamlit/commands/execution_control.py
+++ b/lib/streamlit/commands/execution_control.py
@@ -16,7 +16,7 @@ from typing import NoReturn
 
 from streamlit.runtime.scriptrunner import (
     RerunData,
-    RerunException,
+    OnPurposeRerunException,
     StopException,
     get_script_run_ctx,
 )
@@ -62,7 +62,7 @@ def rerun() -> NoReturn:
         query_string = ctx.query_string
         page_script_hash = ctx.page_script_hash
 
-    raise RerunException(
+    raise OnPurposeRerunException(
         RerunData(
             query_string=query_string,
             page_script_hash=page_script_hash,

--- a/lib/streamlit/runtime/scriptrunner/__init__.py
+++ b/lib/streamlit/runtime/scriptrunner/__init__.py
@@ -25,6 +25,7 @@ from streamlit.runtime.scriptrunner.script_run_context import (
 )
 from streamlit.runtime.scriptrunner.script_runner import (
     RerunException as RerunException,
+    OnPurposeRerunException as OnPurposeRerunException,
 )
 from streamlit.runtime.scriptrunner.script_runner import ScriptRunner as ScriptRunner
 from streamlit.runtime.scriptrunner.script_runner import (

--- a/lib/streamlit/runtime/scriptrunner/script_runner.py
+++ b/lib/streamlit/runtime/scriptrunner/script_runner.py
@@ -657,6 +657,14 @@ class RerunException(ScriptControlException):
         return util.repr_(self)
 
 
+class OnPurposeRerunException(RerunException):
+    """Exception raised when the user has requested a rerun.
+
+    This is seperarate from RerunException so we can distinguish between the
+    two in an exception handler.
+    """
+
+
 def _clean_problem_modules() -> None:
     """Some modules are stateful, so we have to clear their state."""
 


### PR DESCRIPTION
Midgard catches `RerunException`s when displaying pages to handle when a user tries to do something before the page is fully loaded. But that messes up `st.experimental_rerun()` which raises this exception to re run the page. Therefore, I created a new exception that differentiates between the two.